### PR TITLE
各Resolverの一覧をpanchira/extensionsで管理

### DIFF
--- a/lib/panchira.rb
+++ b/lib/panchira.rb
@@ -7,12 +7,10 @@ require 'json'
 
 require_relative 'panchira/version'
 require_relative 'panchira/resolvers/resolver'
-require_relative 'panchira/resolvers/dlsite_resolver'
-require_relative 'panchira/resolvers/komiflo_resolver'
-require_relative 'panchira/resolvers/melonbooks_resolver'
-require_relative 'panchira/resolvers/nijie_resolver'
-require_relative 'panchira/resolvers/pixiv_resolver'
-require_relative 'panchira/resolvers/narou_resolver'
+require_relative 'panchira/extensions'
+
+project_root = File.dirname(File.absolute_path(__FILE__))
+Dir.glob(project_root + '/panchira/resolvers/*_resolver.rb').sort.each { |file| require file }
 
 # Main Panchira code goes here.
 module Panchira
@@ -27,22 +25,11 @@ module Panchira
     private
 
     def select_resolver(url)
-      case url
-      when %r{komiflo\.com(?:/#!)?/comics/(\d+)}
-        Panchira::KomifloResolver
-      when %r{melonbooks.co.jp/detail/detail.php\?product_id=(\d+)}
-        Panchira::MelonbooksResolver
-      when %r{pixiv\.net/(member_illust.php?.*illust_id=|artworks/)(\d+)}
-        Panchira::PixivResolver
-      when /nijie.*view.*id=\d+/
-        Panchira::NijieResolver
-      when /dlsite/
-        Panchira::DlsiteResolver
-      when %r{novel18\.syosetu\.com/}
-        Panchira::NarouResolver
-      else
-        Panchira::Resolver
+      Panchira::Extensions.resolvers.each do |resolver|
+        return resolver if url =~ resolver::URL_REGEXP
       end
+
+      Panchira::Resolver
     end
   end
 end

--- a/lib/panchira.rb
+++ b/lib/panchira.rb
@@ -26,7 +26,7 @@ module Panchira
 
     def select_resolver(url)
       Panchira::Extensions.resolvers.each do |resolver|
-        return resolver if url =~ resolver::URL_REGEXP
+        return resolver if resolver.applicable?(url)
       end
 
       Panchira::Resolver

--- a/lib/panchira/extensions.rb
+++ b/lib/panchira/extensions.rb
@@ -6,7 +6,7 @@ module Panchira
 
     class << self
       # Register a resolver class which extends Panchira::Resolver.
-      def register_resolver(resolver)
+      def register(resolver)
         @resolvers.push(resolver) unless @resolvers.include?(resolver)
       end
 

--- a/lib/panchira/extensions.rb
+++ b/lib/panchira/extensions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Panchira
+  module Extensions
+    @resolvers = []
+
+    class << self
+      # Register a resolver class which extends Panchira::Resolver.
+      def register_resolver(resolver)
+        @resolvers.push(resolver) unless @resolvers.include?(resolver)
+      end
+
+      attr_reader :resolvers
+    end
+  end
+end

--- a/lib/panchira/resolvers/dlsite_resolver.rb
+++ b/lib/panchira/resolvers/dlsite_resolver.rb
@@ -10,4 +10,6 @@ module Panchira
       @page.css('//meta[property="og:image"]/@content').first.to_s.sub(/sam/, 'main')
     end
   end
+
+  ::Panchira::Extensions.register_resolver(Panchira::DlsiteResolver)
 end

--- a/lib/panchira/resolvers/dlsite_resolver.rb
+++ b/lib/panchira/resolvers/dlsite_resolver.rb
@@ -2,6 +2,8 @@
 
 module Panchira
   class DlsiteResolver < Resolver
+    URL_REGEXP = /dlsite/.freeze
+
     private
 
     def parse_image_url

--- a/lib/panchira/resolvers/dlsite_resolver.rb
+++ b/lib/panchira/resolvers/dlsite_resolver.rb
@@ -11,5 +11,5 @@ module Panchira
     end
   end
 
-  ::Panchira::Extensions.register_resolver(Panchira::DlsiteResolver)
+  ::Panchira::Extensions.register(Panchira::DlsiteResolver)
 end

--- a/lib/panchira/resolvers/komiflo_resolver.rb
+++ b/lib/panchira/resolvers/komiflo_resolver.rb
@@ -4,10 +4,12 @@ module Panchira
   # KomifloResolver resolves Komiflo.
   # Komiflo has its API server, so we can utilize it.
   class KomifloResolver < Resolver
+    URL_REGEXP = %r{komiflo\.com(?:/#!)?/comics/(\d+)}.freeze
+
     def initialize(url)
       @url = url
 
-      @id = url.slice(%r{komiflo\.com(?:/#!)?/comics/(\d+)}, 1)
+      @id = url.slice(URL_REGEXP, 1)
       raw_json = URI.parse("https://api.komiflo.com/content/id/#{@id}").read('User-Agent' => USER_AGENT)
       @json = JSON.parse(raw_json)
     end

--- a/lib/panchira/resolvers/komiflo_resolver.rb
+++ b/lib/panchira/resolvers/komiflo_resolver.rb
@@ -39,5 +39,5 @@ module Panchira
     end
   end
 
-  ::Panchira::Extensions.register_resolver(Panchira::KomifloResolver)
+  ::Panchira::Extensions.register(Panchira::KomifloResolver)
 end

--- a/lib/panchira/resolvers/komiflo_resolver.rb
+++ b/lib/panchira/resolvers/komiflo_resolver.rb
@@ -38,4 +38,6 @@ module Panchira
       'https://komiflo.com/comics/' + id
     end
   end
+
+  ::Panchira::Extensions.register_resolver(Panchira::KomifloResolver)
 end

--- a/lib/panchira/resolvers/melonbooks_resolver.rb
+++ b/lib/panchira/resolvers/melonbooks_resolver.rb
@@ -27,5 +27,5 @@ module Panchira
     end
   end
 
-  ::Panchira::Extensions.register_resolver(Panchira::MelonbooksResolver)
+  ::Panchira::Extensions.register(Panchira::MelonbooksResolver)
 end

--- a/lib/panchira/resolvers/melonbooks_resolver.rb
+++ b/lib/panchira/resolvers/melonbooks_resolver.rb
@@ -2,10 +2,12 @@
 
 module Panchira
   class MelonbooksResolver < Resolver
+    URL_REGEXP = %r{melonbooks.co.jp/detail/detail.php\?product_id=(\d+)}.freeze
+
     private
 
     def parse_canonical_url
-      product_id = @url.slice(%r{melonbooks.co.jp/detail/detail.php\?product_id=(\d+)}, 1)
+      product_id = @url.slice(URL_REGEXP, 1)
       'https://www.melonbooks.co.jp/detail/detail.php?product_id=' + product_id + '&adult_view=1'
     end
 

--- a/lib/panchira/resolvers/melonbooks_resolver.rb
+++ b/lib/panchira/resolvers/melonbooks_resolver.rb
@@ -26,4 +26,6 @@ module Panchira
       @page.css('//meta[property="og:image"]/@content').first.to_s.sub(/&c=1/, '')
     end
   end
+
+  ::Panchira::Extensions.register_resolver(Panchira::MelonbooksResolver)
 end

--- a/lib/panchira/resolvers/narou_resolver.rb
+++ b/lib/panchira/resolvers/narou_resolver.rb
@@ -15,4 +15,6 @@ module Panchira
       Nokogiri::HTML.parse(res.body, uri)
     end
   end
+
+  ::Panchira::Extensions.register_resolver(Panchira::NarouResolver)
 end

--- a/lib/panchira/resolvers/narou_resolver.rb
+++ b/lib/panchira/resolvers/narou_resolver.rb
@@ -4,6 +4,8 @@ require 'net/https'
 
 module Panchira
   class NarouResolver < Resolver
+    URL_REGEXP = %r{novel18\.syosetu\.com/}.freeze
+
     def fetch_page(uri)
       u = URI.parse(uri)
       http = Net::HTTP.new(u.host, u.port)

--- a/lib/panchira/resolvers/narou_resolver.rb
+++ b/lib/panchira/resolvers/narou_resolver.rb
@@ -16,5 +16,5 @@ module Panchira
     end
   end
 
-  ::Panchira::Extensions.register_resolver(Panchira::NarouResolver)
+  ::Panchira::Extensions.register(Panchira::NarouResolver)
 end

--- a/lib/panchira/resolvers/nijie_resolver.rb
+++ b/lib/panchira/resolvers/nijie_resolver.rb
@@ -25,4 +25,6 @@ module Panchira
       end
     end
   end
+
+  ::Panchira::Extensions.register_resolver(Panchira::NijieResolver)
 end

--- a/lib/panchira/resolvers/nijie_resolver.rb
+++ b/lib/panchira/resolvers/nijie_resolver.rb
@@ -26,5 +26,5 @@ module Panchira
     end
   end
 
-  ::Panchira::Extensions.register_resolver(Panchira::NijieResolver)
+  ::Panchira::Extensions.register(Panchira::NijieResolver)
 end

--- a/lib/panchira/resolvers/nijie_resolver.rb
+++ b/lib/panchira/resolvers/nijie_resolver.rb
@@ -2,6 +2,7 @@
 
 module Panchira
   class NijieResolver < Resolver
+    URL_REGEXP = /nijie.*view.*id=\d+/.freeze
 
     private
 

--- a/lib/panchira/resolvers/pixiv_resolver.rb
+++ b/lib/panchira/resolvers/pixiv_resolver.rb
@@ -28,4 +28,6 @@ module Panchira
       @page.css('//meta[property="og:image"]/@content').first.to_s
     end
   end
+
+  ::Panchira::Extensions.register_resolver(Panchira::PixivResolver)
 end

--- a/lib/panchira/resolvers/pixiv_resolver.rb
+++ b/lib/panchira/resolvers/pixiv_resolver.rb
@@ -2,21 +2,22 @@
 
 module Panchira
   class PixivResolver < Resolver
+    URL_REGEXP = %r{pixiv\.net/(member_illust.php?.*illust_id=|artworks/)(\d+)}.freeze
+
     def initialize(url)
       super(url)
-      @illust_id = url.slice(%r{pixiv\.net/(member_illust.php?.*illust_id=|artworks/)(\d+)}, 2)
+      @illust_id = url.slice(URL_REGEXP, 2)
     end
 
     private
 
     def parse_canonical_url
-      illust_id = @url.slice(%r{pixiv\.net/(member_illust.php?.*illust_id=|artworks/)(\d+)}, 2)
-      'https://pixiv.net/member_illust.php?mode=medium&illust_id=' + illust_id
+      'https://pixiv.net/member_illust.php?mode=medium&illust_id=' + @illust_id
     end
 
     def parse_image_url
       proxy_url = "https://pixiv.cat/#{@illust_id}.jpg"
-      
+
       case Net::HTTP.get_response(URI.parse(proxy_url))
       when Net::HTTPNotFound
         proxy_url = "https://pixiv.cat/#{@illust_id}-1.jpg"

--- a/lib/panchira/resolvers/pixiv_resolver.rb
+++ b/lib/panchira/resolvers/pixiv_resolver.rb
@@ -29,5 +29,5 @@ module Panchira
     end
   end
 
-  ::Panchira::Extensions.register_resolver(Panchira::PixivResolver)
+  ::Panchira::Extensions.register(Panchira::PixivResolver)
 end

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -5,6 +5,10 @@
 # and is inherited by the other resolvers.
 module Panchira
   class Resolver
+    # The URL pattern that this resolver tries to resolve.
+    # Should be redefined in subclasses.
+    URL_REGEXP = URI::DEFAULT_PARSER.make_regexp
+
     USER_AGENT = "Mozilla/5.0 (compatible; Panchira/#{VERSION}; +https://github.com/nuita/panchira)"
 
     def initialize(url)

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -32,6 +32,13 @@ module Panchira
       attributes
     end
 
+    class << self
+      # Tell whether the url is applicable for this resolver.
+      def applicable?(url)
+        url =~ self::URL_REGEXP
+      end
+    end
+
     private
 
     def fetch_page(url)


### PR DESCRIPTION
- Resolverの一覧をPanchira::Extensions::resolversで管理
- Panchira::Extensions.register(Panchira::***Resolver) でResolverを登録できる
- Resolverの適用条件はResolver::URL_REGEXPとのマッチにまとめられた