### PR TITLE
Panchira#fetchの返り値をハッシュからクラスに変更

### DIFF
--- a/lib/panchira.rb
+++ b/lib/panchira.rb
@@ -16,7 +16,7 @@ Dir.glob(project_root + '/panchira/resolvers/*_resolver.rb').sort.each { |file| 
 # Main Panchira code goes here.
 module Panchira
   class << self
-    # Fetch the given URL and returns a hash that contains attributes of hentai.
+    # Fetch the given URL and returns a PanchiraResult.
     def fetch(url)
       resolver = select_resolver(url)
 

--- a/lib/panchira.rb
+++ b/lib/panchira.rb
@@ -6,6 +6,7 @@ require 'fastimage'
 require 'json'
 
 require_relative 'panchira/version'
+require_relative 'panchira/panchira_result'
 require_relative 'panchira/resolvers/resolver'
 require_relative 'panchira/extensions'
 

--- a/lib/panchira/panchira_result.rb
+++ b/lib/panchira/panchira_result.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Panchira
+  # Image attributes in PanchiraResult.
+  class PanchiraImage
+    attr_accessor :url, :width, :height
+  end
+
+  # Result class for Panchira.fetch.
+  class PanchiraResult
+    attr_accessor :canonical_url, :title, :description, :image
+  end
+end

--- a/lib/panchira/resolvers/komiflo_resolver.rb
+++ b/lib/panchira/resolvers/komiflo_resolver.rb
@@ -30,7 +30,7 @@ module Panchira
 
       parent = @json['content']['parents'][0]['data']['title']
       description = '著: ' + author if author
-      description += " / #{parent}" if parent
+      description + " / #{parent}" if parent
     end
 
     def parse_canonical_url

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -16,20 +16,18 @@ module Panchira
     end
 
     def fetch
-      attributes = {}
+      result = PanchiraResult.new
 
       @page = fetch_page(@url)
-      attributes[:canonical_url] = parse_canonical_url
+      result.canonical_url = parse_canonical_url
 
-      if @url != attributes[:canonical_url]
-        @page = fetch_page(attributes[:canonical_url])
-      end
+      @page = fetch_page(result.canonical_url) if @url != result.canonical_url
 
-      attributes[:title] = parse_title
-      attributes[:description] = parse_description
-      attributes[:image] = parse_image
+      result.title = parse_title
+      result.description = parse_description
+      result.image = parse_image
 
-      attributes
+      result
     end
 
     class << self

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -70,9 +70,9 @@ module Panchira
     end
 
     def parse_image
-      image = {}
-      image[:url] = parse_image_url
-      image[:width], image[:height] = FastImage.size(image[:url])
+      image = PanchiraImage.new
+      image.url = parse_image_url
+      image.width, image.height = FastImage.size(image.url)
 
       image
     end

--- a/test/panchira_test.rb
+++ b/test/panchira_test.rb
@@ -10,27 +10,29 @@ class PanchiraTest < Minitest::Test
   def test_fetch_data_generally
     # hikakinTV
     url = 'https://www.youtube.com/user/HikakinTV'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_equal 'HikakinTV', attributes[:title]
-    assert_match 'ヒカキン', attributes[:description]
-    assert_equal %i[url width height], attributes[:image].keys
+    assert_equal 'HikakinTV', result.title
+    assert_match 'ヒカキン', result.description
+    assert result.image.url
+    assert result.image.width
+    assert result.image.height
 
     # please follow me on Instagram!
     url = 'https://www.instagram.com/_kypkyp/'
-    attributes = Panchira.fetch(url)
-    assert_match 'Instagram', attributes[:title]
-    assert_match 'kypkyp', attributes[:description]
+    result = Panchira.fetch(url)
+    assert_match 'Instagram', result.title
+    assert_match 'kypkyp', result.description
   end
 
   def test_fetch_canonical_url
     url = 'https://blog.hubspot.jp/canonical-url?hogehoge=1'
-    attributes = Panchira.fetch(url)
-    assert_equal 'https://blog.hubspot.jp/canonical-url', attributes[:canonical_url]
+    result = Panchira.fetch(url)
+    assert_equal 'https://blog.hubspot.jp/canonical-url', result.canonical_url
 
     # it's ok if you don't have canonical url
     url = 'https://example.com/'
-    attributes = Panchira.fetch(url)
-    assert_equal 'https://example.com/', attributes[:canonical_url]
+    result = Panchira.fetch(url)
+    assert_equal 'https://example.com/', result.canonical_url
   end
 end

--- a/test/resolvers/dlsite_test.rb
+++ b/test/resolvers/dlsite_test.rb
@@ -5,10 +5,10 @@ require 'test_helper'
 class DLSiteTest < Minitest::Test
   def test_fetch_dlsite
     url = 'https://www.dlsite.com/maniax-touch/dlaf/=/t/p/link/work/aid/miuuu/id/RJ255695.html'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_match '性欲処理される生活。', attributes[:title]
-    assert_match '事務的な双子メイドが、両耳から囁きながら、ご主人様のおちんぽのお世話をしてくれます♪', attributes[:description]
-    assert_equal 'https://img.dlsite.jp/modpub/images2/work/doujin/RJ256000/RJ255695_img_main.jpg', attributes[:image][:url]
+    assert_match '性欲処理される生活。', result.title
+    assert_match '事務的な双子メイドが、両耳から囁きながら、ご主人様のおちんぽのお世話をしてくれます♪', result.description
+    assert_equal 'https://img.dlsite.jp/modpub/images2/work/doujin/RJ256000/RJ255695_img_main.jpg', result.image.url
   end
 end

--- a/test/resolvers/komiflo_test.rb
+++ b/test/resolvers/komiflo_test.rb
@@ -5,11 +5,11 @@ require 'test_helper'
 class KomifloTest < Minitest::Test
   def test_fetch_komiflo
     url = 'https://komiflo.com/#!/comics/4635/read/page/3'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_equal 'https://komiflo.com/comics/4635', attributes[:canonical_url]
-    assert_match '晴れ時々露出予報', attributes[:title]
-    assert_match 'NAZ', attributes[:description]
-    assert_equal 'https://t.komiflo.com/564_mobile_large_3x/contents/cdcfb81ea67a74519b8ad9dea6de8c5d4cec9f9f.jpg', attributes[:image][:url]
+    assert_equal 'https://komiflo.com/comics/4635', result.canonical_url
+    assert_match '晴れ時々露出予報', result.title
+    assert_match 'NAZ', result.description
+    assert_equal 'https://t.komiflo.com/564_mobile_large_3x/contents/cdcfb81ea67a74519b8ad9dea6de8c5d4cec9f9f.jpg', result.image.url
   end
 end

--- a/test/resolvers/melonbooks_test.rb
+++ b/test/resolvers/melonbooks_test.rb
@@ -2,22 +2,22 @@
 
 require 'test_helper'
 
-class MelonbooksTest < Minitest::Test 
+class MelonbooksTest < Minitest::Test
   def test_fetch_melonbooks
     url = 'https://www.melonbooks.co.jp/detail/detail.php?product_id=319663'
 
-    attributes = Panchira.fetch(url)
-    assert_match 'https://www.melonbooks.co.jp/detail/detail.php?product_id=319663&adult_view=1', attributes[:canonical_url]
-    assert_match 'めちゃシコごちうさアソート', attributes[:title]
-    assert_match 'image=212001143963.jpg', attributes[:image][:url]
-    assert_match (/^(?!.*c=1).*$/), attributes[:image][:url]
-    assert_match 'めちゃシコシリーズ', attributes[:description]
+    result = Panchira.fetch(url)
+    assert_match 'https://www.melonbooks.co.jp/detail/detail.php?product_id=319663&adult_view=1', result.canonical_url
+    assert_match 'めちゃシコごちうさアソート', result.title
+    assert_match 'image=212001143963.jpg', result.image.url
+    assert_match(/^(?!.*c=1).*$/, result.image.url)
+    assert_match 'めちゃシコシリーズ', result.description
 
     # Page structure in melonbooks changes if there is a review from staff.
     url = 'https://www.melonbooks.co.jp/detail/detail.php?product_id=242938'
-    
-    attributes = Panchira.fetch(url)
-    assert_match 'ぬめぬめ', attributes[:title]
-    assert_match '諏訪子様にショタがいじめられる話です。', attributes[:description] # kawaisou...
+
+    result = Panchira.fetch(url)
+    assert_match 'ぬめぬめ', result.title
+    assert_match '諏訪子様にショタがいじめられる話です。', result.description # kawaisou...
   end
 end

--- a/test/resolvers/narou_test.rb
+++ b/test/resolvers/narou_test.rb
@@ -5,15 +5,15 @@ require 'test_helper'
 class NarouTest < Minitest::Test
   def test_fetch_narou
     url = 'https://novel18.syosetu.com/n9235cz/116/'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_match '知らないうちに催眠ハーレム生徒会', attributes[:title]
-    assert_match '新型コロナウイルス', attributes[:title]
+    assert_match '知らないうちに催眠ハーレム生徒会', result.title
+    assert_match '新型コロナウイルス', result.title
 
     url = 'https://novel18.syosetu.com/n2468et/'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_match '妹', attributes[:title]
-    assert_match 'ある日、エロゲをプレイしていたところを妹に見られた。', attributes[:description]
+    assert_match '妹', result.title
+    assert_match 'ある日、エロゲをプレイしていたところを妹に見られた。', result.description
   end
 end

--- a/test/resolvers/nijie_test.rb
+++ b/test/resolvers/nijie_test.rb
@@ -2,27 +2,27 @@
 
 require 'test_helper'
 
-class NijieTest < Minitest::Test 
+class NijieTest < Minitest::Test
   def test_fetch_nijie
     # Canonical url should normalize mobile url.
     url = 'https://sp.nijie.info/view_popup.php?id=319985'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_equal 'https://nijie.info/view.php?id=319985', attributes[:canonical_url]
-    assert_match '発情めめめ', attributes[:title]
+    assert_equal 'https://nijie.info/view.php?id=319985', result.canonical_url
+    assert_match '発情めめめ', result.title
 
     # Fetch thumbnail if the hentai is an animated GIF.
     url = 'http://nijie.info/view.php?id=177736'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_match '__rs_l160x160', attributes[:image][:url]
+    assert_match '__rs_l160x160', result.image.url
 
     # Picture test for nijie.
     url = 'https://nijie.info/view.php?id=322323'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_equal 'https://pic.nijie.net/05/nijie_picture/3965_20190710041444_0.png', attributes[:image][:url]
-    assert_equal 1764, attributes[:image][:width]
-    assert_equal 1876, attributes[:image][:height]
+    assert_equal 'https://pic.nijie.net/05/nijie_picture/3965_20190710041444_0.png', result.image.url
+    assert_equal 1764, result.image.width
+    assert_equal 1876, result.image.height
   end
 end

--- a/test/resolvers/pixiv_test.rb
+++ b/test/resolvers/pixiv_test.rb
@@ -2,30 +2,30 @@
 
 require 'test_helper'
 
-class PixivTest < Minitest::Test 
-  def test_fetch_pixiv 
+class PixivTest < Minitest::Test
+  def test_fetch_pixiv
     # This art is not matured content, but look at this cute girl!
     url = 'https://www.pixiv.net/member_illust.php?mode=medium&illust_id=73718144'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_match 'んあー・・・', attributes[:title]
-    assert_match 'ん？あげませんよ！', attributes[:description]
-    assert_equal 'https://pixiv.cat/73718144.jpg', attributes[:image][:url]
+    assert_match 'んあー・・・', result.title
+    assert_match 'ん？あげませんよ！', result.description
+    assert_equal 'https://pixiv.cat/73718144.jpg', result.image.url
 
     # Fetch the first page if it is manga.
     url = 'https://www.pixiv.net/member_illust.php?mode=medium&illust_id=75871400'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_match 'DWU', attributes[:title]
-    assert_match '浅瀬', attributes[:description]
-    assert_equal 'https://pixiv.cat/75871400-1.jpg', attributes[:image][:url]
+    assert_match 'DWU', result.title
+    assert_match '浅瀬', result.description
+    assert_equal 'https://pixiv.cat/75871400-1.jpg', result.image.url
 
     # Look at this new url format.
     url = 'https://www.pixiv.net/artworks/78296385'
-    attributes = Panchira.fetch(url)
+    result = Panchira.fetch(url)
 
-    assert_match '女子大生セッッ', attributes[:title]
-    assert_match 'ノポン人', attributes[:description]
-    assert_equal 'https://pixiv.cat/78296385-1.jpg', attributes[:image][:url]
+    assert_match '女子大生セッッ', result.title
+    assert_match 'ノポン人', result.description
+    assert_equal 'https://pixiv.cat/78296385-1.jpg', result.image.url
   end
 end


### PR DESCRIPTION
close #4 

- 取得したページを表す `PanchiraResult`, 取得した画像（URL, 大きさ）を表す `PanchiraImage` クラスを作成
  - 全部attr_accessorつけてオープンに使う
- `Panchira#fetch` の返り値は `PanchiraResult` を返す
- 既存テストをこの仕様に合わせて変更