### PR TITLE
add twitter resolver

### DIFF
--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -45,7 +45,7 @@ module Panchira
     private
 
     def fetch_page(url)
-      raw_page = URI.parse(url).read('User-Agent' => USER_AGENT)
+      raw_page = URI.parse(url).read('User-Agent' => self.class::USER_AGENT)
       charset = raw_page.charset
       Nokogiri::HTML.parse(raw_page, url, charset)
     end

--- a/lib/panchira/resolvers/twitter_resolver.rb
+++ b/lib/panchira/resolvers/twitter_resolver.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Panchira
+  class TwitterResolver < Resolver
+    URL_REGEXP = %r{twitter.com}.freeze
+    USER_AGENT = "facebookexternalhit/1.1 (compatible; Panchira/#{VERSION}; +https://github.com/nuita/panchira)"
+  end
+
+  ::Panchira::Extensions.register(Panchira::TwitterResolver)
+end

--- a/test/resolvers/twitter_test.rb
+++ b/test/resolvers/twitter_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TwitterTest < Minitest::Test
+  def test_fetch_twitter
+    url = 'https://twitter.com/mirakuru_rodeo/status/1266016566769926144'
+    result = Panchira.fetch(url)
+
+    assert_match 'みらくるる', result.title
+    assert_match '2巻発売中', result.description
+    assert_match 'https://pbs.twimg.com/media', result.image.url
+  end
+end


### PR DESCRIPTION
twitter liteが全体に出るようになって、普通のUAだと `og:image` とかつかなくなったので、 [Facebookクローラー](https://developers.facebook.com/docs/sharing/webmasters/crawler)を名乗ります。