### PR TITLE
NarouResolverのカノニカルURLを小説単位のトップページに変更

### DIFF
--- a/lib/panchira/resolvers/narou_resolver.rb
+++ b/lib/panchira/resolvers/narou_resolver.rb
@@ -14,6 +14,13 @@ module Panchira
 
       Nokogiri::HTML.parse(res.body, uri)
     end
+
+    private
+
+    # set novel root because individual chapter doesn't have metatags.
+    def parse_canonical_url
+      @url.match(%r{https?://novel18.syosetu.com/\w+}).to_s
+    end
   end
 
   ::Panchira::Extensions.register(Panchira::NarouResolver)

--- a/test/resolvers/narou_test.rb
+++ b/test/resolvers/narou_test.rb
@@ -8,7 +8,7 @@ class NarouTest < Minitest::Test
     result = Panchira.fetch(url)
 
     assert_match '知らないうちに催眠ハーレム生徒会', result.title
-    assert_match '新型コロナウイルス', result.title
+    assert_match 'テンプレ現代学園催眠物です。', result.description
 
     url = 'https://novel18.syosetu.com/n2468et/'
     result = Panchira.fetch(url)


### PR DESCRIPTION
迷ったけど、章単位よりは小説単位に統一したほうがDBとしての統一性が出るかと思った

あとはメタタグ取るのに小説のトップページ見なきゃいけないというのも理由としてあったけど、タグは別ページ(`https://novel18.syosetu.com/novelview/infotop/ncode/***/`)にしかないし、結局複数ページ見に行かなきゃダメそう……？