### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 - 2020-08-06
+### Added
+- Added support for Fanza Books.
+- Added support for images.
+- You can now set cookie by overriding Resolver#cookie in individual resolvers.
+
+### Changed
+- Resolver::USER_AGENT changed to Resolver#user_agent.
+
 ## 1.0.0 - 2020-06-23
 ### Added
 - Added support for tags.
@@ -34,6 +43,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Released Panchira gem. At this time we can parse only 5 websites.
 
+[1.1.0]: https://github.com/nuita/panchira/releases/tag/v1.1.0
+[1.0.0]: https://github.com/nuita/panchira/releases/tag/v1.0.0
 [0.3.0]: https://github.com/nuita/panchira/releases/tag/v0.3.0
 [0.2.0]: https://github.com/nuita/panchira/releases/tag/v0.2.0
 [0.1.1]: https://github.com/nuita/panchira/releases/tag/v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.1.0 - 2020-08-06
 ### Added
 - Added support for Fanza Books.
-- Added support for images.
+- Added support for direct links to an image.
 - You can now set cookie by overriding Resolver#cookie in individual resolvers.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Due to some legal or ethical issues, most hentai and NSFW platforms don't clarify their content on meta tags. As a result, most hentai platforms are rendered poorly on the card previews on social media.
 
-To solve this issue, Panchira is made to parse correct and uncensored metadata from such web platforms (at this time we cover **DLSite, Komiflo, Melonbooks, Nijie, Pixiv, Shousetsuka ni narou and Twitter**).
+To solve this issue, Panchira is made to parse correct and uncensored metadata from such web platforms (at this time we cover **DLSite, Komiflo, Melonbooks, Nijie, Pixiv, Shousetsuka ni narou, Fanza and Twitter**).
 
 If you need card previews of hentai on your web application, but can't get them with simply parsing metatags, then it is time for Panchira.
 
@@ -16,7 +16,7 @@ This gem is derived from the [Nuita](https://github.com/nuita/nuita) project.
 
 **Please use this gem with appropriate censoring and age-restricting. Never violate local laws and copyrights.**
 
-If you are running one of the websites we cover and feel negative about it, please contact the community or the author([@kypkyp](https://github.com/kypkyp)). 
+If you are running one of the websites we cover and feel negative about this gem, please contact the community or the author([@kypkyp](https://github.com/kypkyp)). 
 
 ## Installation
 

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
## 1.1.0 - 2020-08-06
### Added
- Added support for Fanza Books.
- Added support for direct links to an image.
- You can now set cookie by overriding Resolver#cookie in individual resolvers.

### Changed
- Resolver::USER_AGENT changed to Resolver#user_agent.