### PR TITLE
FANZA書籍の画像取得処理を修正

### DIFF
--- a/lib/panchira/resolvers/fanza_resolver.rb
+++ b/lib/panchira/resolvers/fanza_resolver.rb
@@ -9,7 +9,7 @@ module Panchira
 
       private
 
-      def parse_image
+      def parse_image_url
         @page.css('.m-imgDetailProductPack/@src').first.to_s
       end
 

--- a/test/resolvers/fanza_test.rb
+++ b/test/resolvers/fanza_test.rb
@@ -8,6 +8,6 @@ class FanzaTest < Minitest::Test
     result = Panchira.fetch(url)
 
     assert_match '10から始める英才教育', result.title
-    assert_equal 'https://ebook-assets.dmm.co.jp/digital/e-book/b425aakkg00140/b425aakkg00140pl.jpg', result.image
+    assert_equal 'https://ebook-assets.dmm.co.jp/digital/e-book/b425aakkg00140/b425aakkg00140pl.jpg', result.image.url
   end
 end


### PR DESCRIPTION
うっかり`parse_image_url`の代わりに`parse_image`をオーバーライドしてました。
テストのほうも間違えてたから気づかなかった、こわい……