### PR TITLE
FANZA同人resolver

### DIFF
--- a/lib/panchira/resolvers/fanza_resolver.rb
+++ b/lib/panchira/resolvers/fanza_resolver.rb
@@ -26,6 +26,10 @@ module Panchira
       def parse_tags
         @page.css('.m-boxDetailProductInfo__list__description__item > a').map(&:text)
       end
+
+      def parse_description
+        @page.css('.m-boxDetailProduct__info__story').first&.text.to_s.gsub(/[\n\t]/, '')
+      end
     end
 
     class FanzaDoujinResolver < FanzaResolver

--- a/lib/panchira/resolvers/fanza_resolver.rb
+++ b/lib/panchira/resolvers/fanza_resolver.rb
@@ -4,7 +4,17 @@ require 'net/https'
 
 module Panchira
   module Fanza
-    class FanzaBookResolver < Resolver
+    FANZA_COOKIE = 'age_check_done=1;'
+
+    class FanzaResolver < Resolver
+      private
+
+      def cookie
+        ::Panchira::Fanza::FANZA_COOKIE
+      end
+    end
+
+    class FanzaBookResolver < FanzaResolver
       URL_REGEXP = %r{book\.dmm\.co\.jp\/}.freeze
 
       private
@@ -12,12 +22,19 @@ module Panchira
       def parse_image_url
         @page.css('.m-imgDetailProductPack/@src').first.to_s
       end
+    end
 
-      def cookie
-        'age_check_done=1;'
+    class FanzaDoujinResolver < FanzaResolver
+      URL_REGEXP = %r{dmm\.co\.jp\/dc\/doujin\/}.freeze
+
+      private
+
+      def parse_tags
+        @page.css('.genreTag__item').map { |t| t.text.strip }
       end
     end
   end
 
   ::Panchira::Extensions.register(Panchira::Fanza::FanzaBookResolver)
+  ::Panchira::Extensions.register(Panchira::Fanza::FanzaDoujinResolver)
 end

--- a/lib/panchira/resolvers/fanza_resolver.rb
+++ b/lib/panchira/resolvers/fanza_resolver.rb
@@ -22,6 +22,10 @@ module Panchira
       def parse_image_url
         @page.css('.m-imgDetailProductPack/@src').first.to_s
       end
+
+      def parse_tags
+        @page.css('.m-boxDetailProductInfo__list__description__item > a').map(&:text)
+      end
     end
 
     class FanzaDoujinResolver < FanzaResolver

--- a/test/resolvers/fanza_test.rb
+++ b/test/resolvers/fanza_test.rb
@@ -10,6 +10,12 @@ class FanzaTest < Minitest::Test
     assert_match '10から始める英才教育', result.title
     assert_equal 'https://ebook-assets.dmm.co.jp/digital/e-book/b425aakkg00140/b425aakkg00140pl.jpg', result.image.url
     assert result.tags.include?('ミニ系')
+
+    # the url above doesn't have description, so try with different one:
+    url = 'https://book.dmm.co.jp/detail/k180atkds00971/?dmmref=aComic_List&i3_ord=3&i3_ref=list'
+    result = Panchira.fetch(url)
+    assert_match 'わんぴいす〜美少女捕獲し、日本一周〜', result.title
+    assert_match '※強〇は犯罪です。絶対に手口を模倣しないでください。', result.description
   end
 
   def test_fetch_fanza_doujin

--- a/test/resolvers/fanza_test.rb
+++ b/test/resolvers/fanza_test.rb
@@ -9,6 +9,7 @@ class FanzaTest < Minitest::Test
 
     assert_match '10から始める英才教育', result.title
     assert_equal 'https://ebook-assets.dmm.co.jp/digital/e-book/b425aakkg00140/b425aakkg00140pl.jpg', result.image.url
+    assert result.tags.include?('ミニ系')
   end
 
   def test_fetch_fanza_doujin

--- a/test/resolvers/fanza_test.rb
+++ b/test/resolvers/fanza_test.rb
@@ -10,4 +10,16 @@ class FanzaTest < Minitest::Test
     assert_match '10から始める英才教育', result.title
     assert_equal 'https://ebook-assets.dmm.co.jp/digital/e-book/b425aakkg00140/b425aakkg00140pl.jpg', result.image.url
   end
+
+  def test_fetch_fanza_doujin
+    url = 'https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_184301/'
+    result = Panchira.fetch(url)
+
+    assert_match 'げーみんぐはーれむ', result.title
+    assert_match '不登校でゲームセンスだけが取り柄の僕は日々培った実力を試すべく、', result.description
+    assert result.tags.include?('逆転無し')
+
+    # og:image in Doujin looks large enough.
+    assert_equal 'https://doujin-assets.dmm.co.jp/digital/comic/d_184301/d_184301pr.jpg', result.image.url
+  end
 end


### PR DESCRIPTION
FANZAのクッションページは全部同じcookieで乗り切れる感じがしてきたので、とりあえずFanzaResolverにその処理は共有化した。

ページの仕組みはけっこう違いそうなので、よく使われそうなサービスに対しては別々のResolver作りました。それぞれFanzaResolverを継承します。
呼び出し順が分からない関係でこれ自体を登録できないのがけっこう困るので、呼び出す順番を管理する仕組みが必要かもしれない