### PR TITLE
release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.1 - 2020-08-09
+### Added
+- Added support for Fanza Doujin.
+- Added support for description in Fanza Book.
+
+### Fixed
+- Fixed an issue that fetching image was not working in Fanza Book.
+
 ## 1.1.0 - 2020-08-06
 ### Added
 - Added support for Fanza Books.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.1.0)
+    panchira (1.1.1)
       fastimage (~> 2.1.7)
       nokogiri (~> 1.10.9)
 
@@ -11,7 +11,7 @@ GEM
     fastimage (2.1.7)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     rake (12.3.3)
 

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
ほぼ不完全だったFanzaResolverの修正だから、厳密にはバグフィックスだけじゃないけど1.1.1ってしちゃいます

## 1.1.1 - 2020-08-09
### Added
- Added support for Fanza Doujin.
- Added support for description in Fanza Book.

### Fixed
- Fixed an issue that fetching image was not working in Fanza Book.