### PR TITLE
著者名、サークル名を取得できるようにする

### DIFF
--- a/lib/panchira/panchira_result.rb
+++ b/lib/panchira/panchira_result.rb
@@ -8,6 +8,6 @@ module Panchira
 
   # Result class for Panchira.fetch.
   class PanchiraResult
-    attr_accessor :canonical_url, :title, :description, :image, :tags, :author
+    attr_accessor :canonical_url, :title, :description, :image, :tags, :author, :circle
   end
 end

--- a/lib/panchira/panchira_result.rb
+++ b/lib/panchira/panchira_result.rb
@@ -8,6 +8,6 @@ module Panchira
 
   # Result class for Panchira.fetch.
   class PanchiraResult
-    attr_accessor :canonical_url, :title, :description, :image, :tags
+    attr_accessor :canonical_url, :title, :description, :image, :tags, :author
   end
 end

--- a/lib/panchira/resolvers/dlsite_resolver.rb
+++ b/lib/panchira/resolvers/dlsite_resolver.rb
@@ -6,6 +6,32 @@ module Panchira
 
     private
 
+    # DLSiteのタイトルの[]に含まれている値はtitleタグだとサークル名 or 出版社名だが、
+    # Panchiraが優先するog:titleではサークル名 or 著者名 となる。
+    # 取得に際しては、以下の3パターンを考慮する必要があるため、titleタグとtableの解析が必要となる:
+    # 1) 同人系の一部, 特に音声など。タイトル[サークル名]. 本文中に著者・作者の記載なし
+    # 2) 同人系の一部, 特に一部の同人誌など。タイトル[サークル名]. 本文中に「作者」の記載あり
+    # 3) 商業系。タイトル[著者名]　サークル名なし
+    # 込み入った実装になってしまったため、parse自体をいじる必要があるかも
+    def parse_title
+      @title_md = super.match(/(.+) \[(\S+)\] \|.+/)
+      @title_md[1]
+    end
+
+    def parse_author
+      @page.css('table[id*="work_"] tr').each do |tr|
+        if tr.css('th').text =~ /(作|著)者/
+          return @author = tr.css('td > a').first.text.strip
+        end
+      end
+
+      @author = nil
+    end
+
+    def parse_circle
+      @title_md[2] if @author != @title_md[2]
+    end
+
     def parse_image_url
       @page.css('//meta[property="og:image"]/@content').first.to_s.sub(/sam/, 'main')
     end

--- a/lib/panchira/resolvers/fanza_resolver.rb
+++ b/lib/panchira/resolvers/fanza_resolver.rb
@@ -19,6 +19,10 @@ module Panchira
 
       private
 
+      def parse_author
+        @page.css('.m-boxDetailProductInfoMainList__description__list__item > a').first&.text.to_s
+      end
+
       def parse_image_url
         @page.css('.m-imgDetailProductPack/@src').first.to_s
       end
@@ -36,6 +40,10 @@ module Panchira
       URL_REGEXP = %r{dmm\.co\.jp\/dc\/doujin\/}.freeze
 
       private
+
+      def parse_circle
+        @page.css('a.circleName__txt').first.text
+      end
 
       def parse_tags
         @page.css('.genreTag__item').map { |t| t.text.strip }

--- a/lib/panchira/resolvers/komiflo_resolver.rb
+++ b/lib/panchira/resolvers/komiflo_resolver.rb
@@ -17,20 +17,19 @@ module Panchira
     private
 
     def parse_title
-      comic_title = @json['content']['data']['title']
-      "#{comic_title} | Komiflo"
+      @json['content']['data']['title']
     end
 
     def parse_image_url
       'https://t.komiflo.com/564_mobile_large_3x/' + @json['content']['named_imgs']['cover']['filename']
     end
 
-    def parse_description
-      author = @json['content']['attributes']['artists']['children'][0]['data']['name']
+    def parse_author
+      @json['content']['attributes']['artists']['children'][0]['data']['name']
+    end
 
-      parent = @json['content']['parents'][0]['data']['title']
-      description = '著: ' + author if author
-      description + " / #{parent}" if parent
+    def parse_description
+      @json['content']['parents'][0]['data']['title']
     end
 
     def parse_canonical_url

--- a/lib/panchira/resolvers/melonbooks_resolver.rb
+++ b/lib/panchira/resolvers/melonbooks_resolver.rb
@@ -4,7 +4,40 @@ module Panchira
   class MelonbooksResolver < Resolver
     URL_REGEXP = %r{melonbooks.co.jp/detail/detail.php\?product_id=(\d+)}.freeze
 
+    def fetch
+      result = PanchiraResult.new
+
+      @page = fetch_page(@url)
+      result.canonical_url = parse_canonical_url
+
+      @page = fetch_page(result.canonical_url) if @url != result.canonical_url
+
+      result.title, result.author, result.circle = parse_table
+      result.description = parse_description
+      result.image = parse_image
+      result.tags = parse_tags
+
+      result
+    end
+
     private
+
+    def parse_table
+      title, author, circle = nil, nil, nil
+
+      @page.css('#description > table.stripe > tr').each do |tr|
+        case tr.css('th').text
+        when 'タイトル'
+          title = tr.css('td').text.strip
+        when 'サークル名'
+          circle = tr.css('td > a').text.match(/^(.+)\W\(作品数:/)&.values_at(1)[0]
+        when '作家名'
+          author = tr.css('td > a').text.strip
+        end
+      end
+
+      [title, author, circle]
+    end
 
     def parse_canonical_url
       product_id = @url.slice(URL_REGEXP, 1)

--- a/lib/panchira/resolvers/nijie_resolver.rb
+++ b/lib/panchira/resolvers/nijie_resolver.rb
@@ -6,6 +6,21 @@ module Panchira
 
     private
 
+    def parse_title
+      full_title = super
+      @md = full_title.match(/\A(?<title>.+) \| (?<author>.+)\z/)
+
+      @md[:title]
+    end
+
+    def parse_author
+      @md[:author]
+    end
+
+    def parse_description
+      @page.css('p.illust_description')&.first&.text&.strip
+    end
+
     def parse_canonical_url
       @url.sub(/sp.nijie/, 'nijie').sub(/view_popup/, 'view')
     end

--- a/lib/panchira/resolvers/pixiv_resolver.rb
+++ b/lib/panchira/resolvers/pixiv_resolver.rb
@@ -14,6 +14,14 @@ module Panchira
 
     private
 
+    def parse_title
+      @json['body']['title']
+    end
+
+    def parse_author
+      @json['body']['userName']
+    end
+
     def parse_canonical_url
       'https://pixiv.net/member_illust.php?mode=medium&illust_id=' + @illust_id
     end
@@ -32,7 +40,7 @@ module Panchira
     end
 
     def parse_tags
-      @json['body']['tags']['tags'].map{|content| content['tag']}
+      @json['body']['tags']['tags'].map { |content| content['tag'] }
     end
   end
 

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -29,6 +29,7 @@ module Panchira
       result.description = parse_description
       result.image = parse_image
       result.tags = parse_tags
+      result.author = parse_author
 
       result
     end
@@ -108,6 +109,10 @@ module Panchira
 
     def cookie
       ''
+    end
+
+    def parse_author
+      @page.css('//meta[name="author"]/@content').first.to_s
     end
 
     def user_agent

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -30,6 +30,7 @@ module Panchira
       result.image = parse_image
       result.tags = parse_tags
       result.author = parse_author
+      result.circle = parse_circle
 
       result
     end
@@ -113,6 +114,10 @@ module Panchira
 
     def parse_author
       @page.css('//meta[name="author"]/@content').first.to_s
+    end
+
+    def parse_circle
+      nil
     end
 
     def user_agent

--- a/test/panchira_test.rb
+++ b/test/panchira_test.rb
@@ -17,6 +17,10 @@ class PanchiraTest < Minitest::Test
     assert result.image.url
     assert result.image.width
     assert result.image.height
+
+    url = 'https://kmc.gr.jp'
+    result = Panchira.fetch(url)
+    assert_match 'KMC', result.author
   end
 
   def test_fetch_canonical_url

--- a/test/resolvers/dlsite_test.rb
+++ b/test/resolvers/dlsite_test.rb
@@ -4,12 +4,25 @@ require 'test_helper'
 
 class DLSiteTest < Minitest::Test
   def test_fetch_dlsite
+    # Doujin Onsei with circle and without author.
     url = 'https://www.dlsite.com/maniax-touch/dlaf/=/t/p/link/work/aid/miuuu/id/RJ255695.html'
     result = Panchira.fetch(url)
 
     assert_match '性欲処理される生活。', result.title
     assert_match '事務的な双子メイドが、両耳から囁きながら、ご主人様のおちんぽのお世話をしてくれます♪', result.description
+    assert_match '防鯖潤滑剤', result.circle
+    assert_nil result.author
     assert_equal 'https://img.dlsite.jp/modpub/images2/work/doujin/RJ256000/RJ255695_img_main.jpg', result.image.url
     assert result.tags.include?('淫語')
+
+    # Shogyo with author and without circle. I personally love this book.
+    url = 'https://www.dlsite.com/books/work/=/product_id/BJ066976.html'
+    result = Panchira.fetch(url)
+
+    assert_match 'ミルク*クラウン', result.title
+    assert_match '全ドM男子&ドS女子必携!', result.description
+    assert_match '豆', result.author
+    assert_nil result.circle
+    assert result.tags.include?('SM')
   end
 end

--- a/test/resolvers/fanza_test.rb
+++ b/test/resolvers/fanza_test.rb
@@ -16,6 +16,7 @@ class FanzaTest < Minitest::Test
     result = Panchira.fetch(url)
     assert_match 'わんぴいす〜美少女捕獲し、日本一周〜', result.title
     assert_match '※強〇は犯罪です。絶対に手口を模倣しないでください。', result.description
+    assert_equal 'クジラックス', result.author
   end
 
   def test_fetch_fanza_doujin
@@ -24,6 +25,7 @@ class FanzaTest < Minitest::Test
 
     assert_match 'げーみんぐはーれむ', result.title
     assert_match '不登校でゲームセンスだけが取り柄の僕は日々培った実力を試すべく、', result.description
+    assert_equal '笹森トモエ', result.circle
     assert result.tags.include?('逆転無し')
 
     # og:image in Doujin looks large enough.

--- a/test/resolvers/komiflo_test.rb
+++ b/test/resolvers/komiflo_test.rb
@@ -8,8 +8,9 @@ class KomifloTest < Minitest::Test
     result = Panchira.fetch(url)
 
     assert_equal 'https://komiflo.com/comics/4635', result.canonical_url
-    assert_match '晴れ時々露出予報', result.title
-    assert_match 'NAZ', result.description
+    assert_equal '晴れ時々露出予報', result.title
+    assert_equal 'NAZ', result.author
+    assert_match 'メガストア', result.description
     assert_equal 'https://t.komiflo.com/564_mobile_large_3x/contents/cdcfb81ea67a74519b8ad9dea6de8c5d4cec9f9f.jpg', result.image.url
     assert result.tags.include?('オナニー')
   end

--- a/test/resolvers/melonbooks_test.rb
+++ b/test/resolvers/melonbooks_test.rb
@@ -8,7 +8,9 @@ class MelonbooksTest < Minitest::Test
 
     result = Panchira.fetch(url)
     assert_match 'https://www.melonbooks.co.jp/detail/detail.php?product_id=319663&adult_view=1', result.canonical_url
-    assert_match 'めちゃシコごちうさアソート', result.title
+    assert_equal 'めちゃシコごちうさアソート', result.title
+    assert_equal '高階聖人', result.author
+    assert_equal '47sp.', result.circle
     assert_match 'image=212001143963.jpg', result.image.url
     assert_match(/^(?!.*c=1).*$/, result.image.url)
     assert_match 'めちゃシコシリーズ', result.description

--- a/test/resolvers/narou_test.rb
+++ b/test/resolvers/narou_test.rb
@@ -9,6 +9,7 @@ class NarouTest < Minitest::Test
 
     assert_match '知らないうちに催眠ハーレム生徒会', result.title
     assert_match '新型コロナウイルス', result.title
+    assert_equal '踏台昇降運動', result.author
     assert result.tags.include?('ハーレム')
   end
 
@@ -18,6 +19,7 @@ class NarouTest < Minitest::Test
 
     assert_match '妹', result.title
     assert_match 'ある日、エロゲをプレイしていたところを妹に見られた。', result.description
+    assert_equal '風見　源一郎', result.author
     assert result.tags.include?('オナニー')
   end
 
@@ -26,6 +28,7 @@ class NarouTest < Minitest::Test
     result = Panchira.fetch(url)
 
     assert_match '太宰治、異世界転生して勇者になる', result.title
+    assert_equal '高橋弘', result.author
     assert result.tags.include?('太宰治')
   end
 
@@ -36,6 +39,7 @@ class NarouTest < Minitest::Test
 
     assert_match 'スコップ無双', result.title
     assert_match 'プロローグ', result.title
+    assert_equal 'ZAP', result.author
     assert result.tags.include?('主人公最強')
   end
 end

--- a/test/resolvers/nijie_test.rb
+++ b/test/resolvers/nijie_test.rb
@@ -9,7 +9,9 @@ class NijieTest < Minitest::Test
     result = Panchira.fetch(url)
 
     assert_equal 'https://nijie.info/view.php?id=319985', result.canonical_url
-    assert_match '発情めめめ', result.title
+    assert_equal '発情めめめ', result.title
+    assert_equal 'santatsuki', result.author
+    assert_match '抗えない〜', result.description
     assert result.tags.include?('バーチャルYouTuber')
 
     # Fetch thumbnail if the hentai is an animated GIF.

--- a/test/resolvers/pixiv_test.rb
+++ b/test/resolvers/pixiv_test.rb
@@ -8,8 +8,9 @@ class PixivTest < Minitest::Test
     url = 'https://www.pixiv.net/member_illust.php?mode=medium&illust_id=73718144'
     result = Panchira.fetch(url)
 
-    assert_match 'んあー・・・', result.title
+    assert_equal 'んあー・・・', result.title
     assert_match 'ん？あげませんよ！', result.description
+    assert_match 'パイングミ', result.author
     assert_equal 'https://pixiv.cat/73718144.jpg', result.image.url
     assert result.tags.include?('VOICEROID')
 
@@ -17,8 +18,9 @@ class PixivTest < Minitest::Test
     url = 'https://www.pixiv.net/member_illust.php?mode=medium&illust_id=75871400'
     result = Panchira.fetch(url)
 
-    assert_match 'DWU', result.title
+    assert_equal 'DWU', result.title
     assert_match '浅瀬', result.description
+    assert_match 'かにかま', result.author
     assert_equal 'https://pixiv.cat/75871400-1.jpg', result.image.url
     assert result.tags.include?('DWU')
 
@@ -26,8 +28,9 @@ class PixivTest < Minitest::Test
     url = 'https://www.pixiv.net/artworks/78296385'
     result = Panchira.fetch(url)
 
-    assert_match '女子大生セッッ', result.title
+    assert_equal '女子大生セッッ', result.title
     assert_match 'ノポン人', result.description
+    assert_match 'MだSたろう', result.author
     assert_equal 'https://pixiv.cat/78296385-1.jpg', result.image.url
     assert result.tags.include?('ハナ')
   end


### PR DESCRIPTION
著者名とかサークル名を取得できるようにしました。思ったよりmetaタグに書いてくれてるサイトなくて巨大PRになってしまった……。

タイトルに著者名が含まれてるサイトとかも多いので、それを解析する過程でタイトル自体の値も変わっているものがあります。