### PR TITLE
release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.0 - 2020-10-31
+### Added
+- You can now fetch author and circle name in resolvers (Resolver#fetch_author, Resolver#fetch_circle).
+
+### Changed
+- Resolver#fetch_title returns the title of the content (not the original title of the page).
+
 ## 1.1.1 - 2020-08-09
 ### Added
 - Added support for Fanza Doujin.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.1.1)
+    panchira (1.2.0)
       fastimage (~> 2.1.7)
       nokogiri (~> 1.10.9)
 
@@ -10,7 +10,7 @@ GEM
   specs:
     fastimage (2.1.7)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
+    minitest (5.14.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     rake (12.3.3)

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
## 1.2.0 - 2020-10-31
### Added
- You can now fetch author and circle name in resolvers (Resolver#fetch_author, Resolver#fetch_circle).

### Changed
- Resolver#fetch_title returns the title of the content (not the original title of the page).