### PR TITLE
取得したResolverの名前をPanchiraResultに追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
   Exclude:
     - bin/*
     - vendor/bundle/**/*
+  SuggestExtensions: false
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent

--- a/lib/panchira/panchira_result.rb
+++ b/lib/panchira/panchira_result.rb
@@ -8,6 +8,6 @@ module Panchira
 
   # Result class for Panchira.fetch.
   class PanchiraResult
-    attr_accessor :canonical_url, :title, :description, :image, :tags, :author, :circle
+    attr_accessor :canonical_url, :title, :description, :image, :tags, :author, :circle, :resolver
   end
 end

--- a/lib/panchira/resolvers/image_resolver.rb
+++ b/lib/panchira/resolvers/image_resolver.rb
@@ -9,6 +9,7 @@ module Panchira
       result.canonical_url = @url
       result.image = PanchiraImage.new
       result.image.url = @url
+      result.resolver = parse_resolver
       result
     end
   end

--- a/lib/panchira/resolvers/melonbooks_resolver.rb
+++ b/lib/panchira/resolvers/melonbooks_resolver.rb
@@ -16,6 +16,7 @@ module Panchira
       result.description = parse_description
       result.image = parse_image
       result.tags = parse_tags
+      result.resolver = parse_resolver
 
       result
     end

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -31,6 +31,7 @@ module Panchira
       result.tags = parse_tags
       result.author = parse_author
       result.circle = parse_circle
+      result.resolver = parse_resolver
 
       result
     end
@@ -118,6 +119,10 @@ module Panchira
 
       def parse_circle
         nil
+      end
+
+      def parse_resolver
+        self.class.to_s
       end
 
       def user_agent

--- a/test/panchira_test.rb
+++ b/test/panchira_test.rb
@@ -17,6 +17,7 @@ class PanchiraTest < Minitest::Test
     assert result.image.url
     assert result.image.width
     assert result.image.height
+    assert_equal 'Panchira::Resolver', result.resolver
 
     url = 'https://kmc.gr.jp'
     result = Panchira.fetch(url)

--- a/test/resolvers/dlsite_test.rb
+++ b/test/resolvers/dlsite_test.rb
@@ -8,6 +8,7 @@ class DLSiteTest < Minitest::Test
     url = 'https://www.dlsite.com/maniax-touch/dlaf/=/t/p/link/work/aid/miuuu/id/RJ255695.html'
     result = Panchira.fetch(url)
 
+    assert_equal 'Panchira::DlsiteResolver', result.resolver
     assert_match '性欲処理される生活。', result.title
     assert_match '事務的な双子メイドが、両耳から囁きながら、ご主人様のおちんぽのお世話をしてくれます♪', result.description
     assert_match '防鯖潤滑剤', result.circle

--- a/test/resolvers/komiflo_test.rb
+++ b/test/resolvers/komiflo_test.rb
@@ -7,6 +7,7 @@ class KomifloTest < Minitest::Test
     url = 'https://komiflo.com/#!/comics/4635/read/page/3'
     result = Panchira.fetch(url)
 
+    assert_equal 'Panchira::KomifloResolver', result.resolver
     assert_equal 'https://komiflo.com/comics/4635', result.canonical_url
     assert_equal '晴れ時々露出予報', result.title
     assert_equal 'NAZ', result.author

--- a/test/resolvers/melonbooks_test.rb
+++ b/test/resolvers/melonbooks_test.rb
@@ -7,6 +7,7 @@ class MelonbooksTest < Minitest::Test
     url = 'https://www.melonbooks.co.jp/detail/detail.php?product_id=319663'
 
     result = Panchira.fetch(url)
+    assert_equal 'Panchira::MelonbooksResolver', result.resolver
     assert_match 'https://www.melonbooks.co.jp/detail/detail.php?product_id=319663&adult_view=1', result.canonical_url
     assert_equal 'めちゃシコごちうさアソート', result.title
     assert_equal '高階聖人', result.author

--- a/test/resolvers/nijie_test.rb
+++ b/test/resolvers/nijie_test.rb
@@ -8,6 +8,7 @@ class NijieTest < Minitest::Test
     url = 'https://sp.nijie.info/view_popup.php?id=319985'
     result = Panchira.fetch(url)
 
+    assert_equal 'Panchira::NijieResolver', result.resolver
     assert_equal 'https://nijie.info/view.php?id=319985', result.canonical_url
     assert_equal '発情めめめ', result.title
     assert_equal 'santatsuki', result.author

--- a/test/resolvers/pixiv_test.rb
+++ b/test/resolvers/pixiv_test.rb
@@ -8,6 +8,7 @@ class PixivTest < Minitest::Test
     url = 'https://www.pixiv.net/member_illust.php?mode=medium&illust_id=73718144'
     result = Panchira.fetch(url)
 
+    assert_equal 'Panchira::PixivResolver', result.resolver
     assert_equal 'んあー・・・', result.title
     assert_match 'ん？あげませんよ！', result.description
     assert_match 'パイングミ', result.author


### PR DESCRIPTION
- `PanchiraResult#resolver` を追加
- `Resolver#fetch_resolver()` を追加

https://github.com/nuita/nuita/issues/314

生の`self.class`を渡すと面倒くさそうなので文字列に変換してますが、用途があれば変換せずに渡したほうがいいのかもしれない（思いつかず）