### PR TITLE
複数著者を配列として取れるようになる

### DIFF
--- a/lib/panchira/panchira_result.rb
+++ b/lib/panchira/panchira_result.rb
@@ -8,6 +8,14 @@ module Panchira
 
   # Result class for Panchira.fetch.
   class PanchiraResult
-    attr_accessor :canonical_url, :title, :description, :image, :tags, :author, :circle, :resolver
+    attr_accessor :canonical_url, :title, :description, :image, :tags, :authors, :circle, :resolver
+
+    def author
+      authors&.join(' ')
+    end
+
+    def author=(value)
+      self.authors = [value] if value
+    end
   end
 end

--- a/lib/panchira/resolvers/dlsite_resolver.rb
+++ b/lib/panchira/resolvers/dlsite_resolver.rb
@@ -14,22 +14,24 @@ module Panchira
       # 3) 商業系。タイトル[著者名]　サークル名なし
       # 込み入った実装になってしまったため、parse自体をいじる必要があるかも
       def parse_title
-        @title_md = super.match(/(.+) \[(\S+)\] \|.+/)
+        @title_md = super.match(/(.+) \[(.+)\] \|.+/)
         @title_md[1]
       end
 
-      def parse_author
+      def parse_authors
         @page.css('table[id*="work_"] tr').each do |tr|
-          if tr.css('th').text =~ /(作|著)者/
-            return @author = tr.css('td > a').first.text.strip
+          next unless tr.css('th').text =~ /(作|著)者/
+
+          return @authors = tr.css('td > a').map do |node|
+            node.text.strip
           end
         end
 
-        @author = nil
+        @authors = nil
       end
 
       def parse_circle
-        @title_md[2] if @author != @title_md[2]
+        @title_md[2] if @authors&.slice(0..2)&.join(' ') != @title_md[2]
       end
 
       def parse_image_url

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -29,7 +29,11 @@ module Panchira
       result.description = parse_description
       result.image = parse_image
       result.tags = parse_tags
-      result.author = parse_author
+      if respond_to?(:parse_authors, true)
+        result.authors = parse_authors
+      else
+        result.author = parse_author
+      end
       result.circle = parse_circle
       result.resolver = parse_resolver
 

--- a/test/resolvers/dlsite_test.rb
+++ b/test/resolvers/dlsite_test.rb
@@ -26,4 +26,13 @@ class DLSiteTest < Minitest::Test
     assert_nil result.circle
     assert_includes result.tags, 'SM'
   end
+
+  def test_dlsite_with_multiple_authors
+    url = 'https://www.dlsite.com/books/work/=/product_id/BJ246254.html'
+    result = Panchira.fetch(url)
+
+    assert_includes result.author, 'たかみち'
+    assert_includes result.author, '猫男爵'
+    assert_includes result.author, 'ぼうえん'
+  end
 end


### PR DESCRIPTION
複数の作者を保存するために、`PanchiraResult#author`を削除し、代わりに`PanchiraResult#authors`を追加しました。
従来のコードをそのまま使えるように、以下の変更を加えてあります。

- `PanchiraResult#author()`, `PanchiraResult#author=()` を実装
  - `authors`の値を素の文字列としてget, setできます(setterでは空白文字は配列にsplitされます)。
- `Resolver#fetch()`内で`parse_authors()` から値を取得できるようにする
  - `parse_authors()`が実装されているResolverでは、`parse_author()`を呼び出しません。
  - `parse_authors()`が実装されていないResolverに対しては、これまで通り`parse_author()`を見ます。
  - `Panchira::Resolver`自体には`parse_authors()`は定義されていないので、子クラスで独自に定義しなければ従来どおりの`parse_author()`が呼ばれることになります。