### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0 - 2021-02-06
+### Added
+- Added support for multiple authors. PanchiraResult#authors now returns an array of authors.
+- PanchiraResult now returns a resolver name used in the process (PanchiraResult#resolver).
+
+### Fixed
+- Fixed an issue that fetching DLSite pages with multiple authors were not working.
+- Fixed a slight issue in fetching Melonbooks pages.
+
 ## 1.2.0 - 2020-10-31
 ### Added
 - You can now fetch author and circle name in resolvers (Resolver#fetch_author, Resolver#fetch_circle).
@@ -58,6 +67,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Released Panchira gem. At this time we can parse only 5 websites.
 
+[1.3.0]: https://github.com/nuita/panchira/releases/tag/v1.3.0
+[1.2.0]: https://github.com/nuita/panchira/releases/tag/v1.2.0
 [1.1.0]: https://github.com/nuita/panchira/releases/tag/v1.1.0
 [1.0.0]: https://github.com/nuita/panchira/releases/tag/v1.0.0
 [0.3.0]: https://github.com/nuita/panchira/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed an issue that fetching DLSite pages with multiple authors were not working.
-- Fixed a slight issue in fetching Melonbooks pages.
+- Fixed a slight issue in MelonbooksResolver.
 
 ## 1.2.0 - 2020-10-31
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.2.0)
+    panchira (1.3.0)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.12.0)
 
@@ -10,10 +10,8 @@ GEM
   specs:
     ast (2.4.1)
     fastimage (2.1.7)
-    mini_portile2 (2.5.0)
     minitest (5.14.2)
-    nokogiri (1.11.0)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.0-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.0.0)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Or install it yourself as:
 ```
 > Panchira.fetch("https://www.pixiv.net/artworks/61711172")
 
-=> #<Panchira::PanchiraResult:0x00007fb95d2c53f8 @canonical_url="https://pixiv.net/member_illust.php?mode=medium&illust_id=61711172", @title="#輿水幸子 すずしい顔で締め切りを破る幸子 - むらためのイラスト - pixiv", @description="(UTF16の)Pietで実行すると「すずしい」と出力する幸子(5色+白Pietカラーゴルフ)。解説記事は http://chy72.hatenablog.com/entry/2016/12/24/1", @image=#<Panchira::PanchiraImage:0x00007fb95f126ea0 @url="https://pixiv.cat/61711172.jpg", @width=810, @height=500>, @tags=["輿水幸子", "Piet", "プログラミング"]>
+=> #<Panchira::PanchiraResult:0x00007ff15890e948 @canonical_url="https://pixiv.net/member_illust.php?mode=medium&illust_id=61711172", @title="すずしい顔で締め切りを破る幸子", @description="(UTF16の)Pietで実行すると「すずしい」と出力する幸子(5色+白Pietカラーゴルフ)。解説記事は http://chy72.hatenablog.com/entry/2016/12/24/1", @image=#<Panchira::PanchiraImage:0x00007ff15931fc48 @url="https://pixiv.cat/61711172.jpg", @width=810, @height=500>, @tags=["輿水幸子", "Piet", "プログラミング"], @authors=["むらため"], @circle=nil, @resolver="Panchira::PixivResolver">
 ```
 
 In most situation you would call `Panchira#fetch`. It is a singular method that takes a URI and returns an instance of `PanchiraResult`, which is a simple class that stores the website's information, such as title, description and so on.

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
## 1.3.0 - 2021-02-06
### Added
- Added support for multiple authors. PanchiraResult#authors now returns an array of authors.
- PanchiraResult now returns a resolver name used in the process (PanchiraResult#resolver).

### Fixed
- Fixed an issue that fetching DLSite pages with multiple authors were not working.
- Fixed a slight issue in MelonbooksResolver.