### PR TITLE
FANZA同人のcanonical urlを一旦無効にする

### DIFF
--- a/lib/panchira/resolvers/fanza_resolver.rb
+++ b/lib/panchira/resolvers/fanza_resolver.rb
@@ -41,6 +41,12 @@ module Panchira
 
       private
 
+        # canonical urlに別サービス(FANZA GAMES)のURLが設定されていることがあるため、
+        # 別サービスの場合はとりあえず元URLを設定する
+        def parse_canonical_url
+          @url
+        end
+
         def parse_circle
           @page.css('a.circleName__txt').first.text
         end

--- a/test/resolvers/fanza_test.rb
+++ b/test/resolvers/fanza_test.rb
@@ -20,6 +20,7 @@ class FanzaTest < Minitest::Test
   end
 
   def test_fetch_fanza_doujin
+    # Book
     url = 'https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_184301/'
     result = Panchira.fetch(url)
 
@@ -30,6 +31,14 @@ class FanzaTest < Minitest::Test
 
     # og:image in Doujin looks large enough.
     assert_equal 'https://doujin-assets.dmm.co.jp/digital/comic/d_184301/d_184301pr.jpg', result.image.url
+
+    # Some doujin games have different service(FANZA GAMES) as canonical url in meta tags, so we have to ignore it.
+    url = 'https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_174194/'
+    result = Panchira.fetch(url)
+
+    assert_equal 'https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_174194/', result.canonical_url
+    assert_match '村長さんの悪だくみ THE MOVIE', result.title
+    assert_equal 'ソクラテス', result.circle
   end
 
   def test_fetch_fanza_video


### PR DESCRIPTION
close #46 

FANZA同人のCG作品でcanonical_urlに別サービス(FANZA GAMES)のurlが入っていることがあるので、一旦デフォルトで行っているURLの正規化をやめました。共有ボタンとか色々試した感じ、現状では特に問題起こらなさそうですが、そのうち手でこっちが正規化してあげる必要があるかも？