### PR TITLE
narou_resolverのdescriptionをテーブル内から指定

### DIFF
--- a/lib/panchira/resolvers/narou_resolver.rb
+++ b/lib/panchira/resolvers/narou_resolver.rb
@@ -25,6 +25,10 @@ module Panchira
         Nokogiri::HTML.parse(res.body, uri)
       end
 
+      def parse_description
+        @desc&.xpath('//*[@id="noveltable1"]/tr/td')&.first&.text&.strip
+      end
+
       def parse_author
         @desc&.xpath('//*[@id="noveltable1"]/tr[2]/td')&.text&.strip
       end
@@ -45,6 +49,10 @@ module Panchira
         if id = @url.match(ID_REGEXP)[:id]
           @desc = fetch_page("https://novel18.syosetu.com/novelview/infotop/ncode/#{id}/")
         end
+      end
+
+      def parse_description
+        @desc&.xpath('//*[@id="noveltable1"]/tr/td')&.first&.text&.strip
       end
 
       def parse_author


### PR DESCRIPTION
なろうのog:descriptionがタグ名をjoinしたものを返すようになっていたので、descriptionもテーブルからあらすじの列を取得するようにしました。

1つのテーブルから複数の項目(author, description, tags...)を取得する場合、テーブルの列ごとにeach回して見出しの内容に応じて一気に取得したほうが柔軟な設計になりそう。なので、個別Resolverのメソッドからまとめて@authorとか@description代入できるようにして、本筋のResolverではその後に@authorがnilだったらparse_author呼ぶ、みたいな設計にしたほうが柔軟性が上がって良い気がする。