### PR TITLE
release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.2 - 2021-05-23
+### Fixed
+- Fixed an issue where Fanza Resolver was retrieving incorrect cannonical URLs from meta tags.
+- Fixed an issue where Narou Resolver retrieved wrong descriptions from meta tags.
+
+### Changed
+- Updated dependencies.
+
 ## 1.3.1 - 2021-02-17
 ### Added
 - Added support for Fanza Video.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.3.1)
+    panchira (1.3.2)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.12.0)
 
@@ -10,10 +10,8 @@ GEM
   specs:
     ast (2.4.2)
     fastimage (2.1.7)
-    mini_portile2 (2.5.1)
     minitest (5.14.4)
-    nokogiri (1.11.5)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.5-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.1.1)

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end


### PR DESCRIPTION
## 1.3.2 - 2021-05-23
### Fixed
- Fixed an issue where Fanza Resolver was retrieving incorrect cannonical URLs.
- Fixed an issue where Narou Resolver was retrieving wrong descriptions.

### Changed
- Updated dependencies.