### PR TITLE
DLSiteの取得が失敗する問題を修正

### DIFF
--- a/lib/panchira/resolvers/dlsite_resolver.rb
+++ b/lib/panchira/resolvers/dlsite_resolver.rb
@@ -39,7 +39,13 @@ module Panchira
       end
 
       def parse_tags
-        @page.css('.main_genre').children.children.map(&:text)
+        @page.css('table[id*="work_"] tr').each do |tr|
+          next unless tr.css('th').text =~ /ジャンル/
+
+          return tr.css('td a').map do |node|
+            node.text.strip
+          end
+        end
       end
   end
 

--- a/lib/panchira/resolvers/narou_resolver.rb
+++ b/lib/panchira/resolvers/narou_resolver.rb
@@ -37,6 +37,11 @@ module Panchira
         # つらい。
         @desc&.xpath('//*[@id="noveltable1"]/tr[3]')&.text&.split("\n\n\n")&.dig(1)&.split(' ')
       end
+
+      # og:urlで指定されたncode.syosetu.com/~~~にアクセスすると301で戻されるので何もしない
+      def parse_canonical_url
+        @url
+      end
     end
 
     class NcodeResolver < Resolver
@@ -62,6 +67,11 @@ module Panchira
       def parse_tags
         # めっちゃつらい。
         @desc&.xpath('//*[@id="noveltable1"]/tr[3]')&.text&.split("\n\n\n")&.dig(1)&.delete("\u00A0")&.split(' ')&.grep_v('')
+      end
+
+      # og:urlで指定されたncode.syosetu.com/~~~にアクセスすると301で戻されるので何もしない
+      def parse_canonical_url
+        @url
       end
     end
   end

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -67,6 +67,9 @@ module Panchira
         # fetch page and refresh canonical_url until canonical_url converges.
         loop do
           url_in_res = @page.css('//link[rel="canonical"]/@href').to_s
+          if url_in_res.empty?
+            url_in_res = @page.css('//meta[property="og:url"]/@content').to_s
+          end
 
           if url_in_res.empty?
             return history.last || @url

--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -73,14 +73,14 @@ module Panchira
 
           if url_in_res.empty?
             return history.last || @url
-          else
-            if history.include?(url_in_res) || history.length > 5
-              return url_in_res
-            else
-              history.push(url_in_res)
-              @page = fetch_page(url_in_res)
-            end
           end
+
+          if history.include?(url_in_res) || history.length > 5
+            return url_in_res
+          end
+
+          history.push(url_in_res)
+          @page = fetch_page(url_in_res)
         end
       end
 


### PR DESCRIPTION
DOMの構造が変わったのか、いままで識別に使っていたクラスが他の要素にも貼られるようになってたので、
authorと同じようにテーブルの中身を1行ずつ読むスタイルに変更しました（非効率なのでどうにかしたい）。

あと、リダイレクトが必要なテストケースでカノニカルURLが`og:url`だけで提供されてて認識できてなかったので、`Panchira::Resolver#fetch_canonical_url`もちょっと変更しました（もしかしたら他のテストケース壊れるかも？）。