### PR TITLE
Melonbooks Resolverでwidth制限なしの画像を取得する

### DIFF
--- a/lib/panchira/resolvers/melonbooks_resolver.rb
+++ b/lib/panchira/resolvers/melonbooks_resolver.rb
@@ -57,7 +57,10 @@ module Panchira
       end
 
       def parse_image_url
-        @page.css('//meta[property="og:image"]/@content').first.to_s.sub(/&c=1/, '')
+        url = @page.css('//meta[property="og:image"]/@content').first.to_s
+        image = url.match(/resize_image.php\?image=([^&]+)/)[1]
+
+        "https://melonbooks.akamaized.net/user_data/packages/resize_image.php?image=#{image}"
       end
 
       def parse_tags

--- a/test/resolvers/melonbooks_test.rb
+++ b/test/resolvers/melonbooks_test.rb
@@ -13,9 +13,12 @@ class MelonbooksTest < Minitest::Test
     assert_equal '高階聖人', result.author
     assert_equal '47sp.', result.circle
     assert_match 'image=212001143963.jpg', result.image.url
-    assert_match(/^(?!.*c=1).*$/, result.image.url)
     assert_match 'めちゃシコシリーズ', result.description
     assert_includes result.tags, 'ココア'
+
+    assert_match 'image=', result.image.url
+    assert_match(/^(?!.*c=1).*$/, result.image.url)
+    assert_match(/^(?!.*width=).*$/, result.image.url)
 
     # Page structure in melonbooks changes if there is a review from staff.
     url = 'https://www.melonbooks.co.jp/detail/detail.php?product_id=242938'


### PR DESCRIPTION
Melonbooks Resolverでwidthの制限が残っていたので、imageクエリだけ残してほかはすべて削除する実装に変更しました。