### PR TITLE
Add Twitter resolver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,14 +4,18 @@ PATH
     panchira (1.3.5)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.12.0)
+      twitter-text (~> 3.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
     fastimage (2.1.7)
+    idn-ruby (0.1.2)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
-    nokogiri (1.11.7-x86_64-darwin)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.1.1)
@@ -35,6 +39,12 @@ GEM
     rubocop-minitest (0.12.1)
       rubocop (>= 0.90, < 2.0)
     ruby-progressbar (1.11.0)
+    twitter-text (3.1.0)
+      idn-ruby
+      unf (~> 0.1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
     unicode-display_width (2.0.0)
 
 PLATFORMS

--- a/lib/panchira/resolvers/twitter_resolver.rb
+++ b/lib/panchira/resolvers/twitter_resolver.rb
@@ -1,0 +1,28 @@
+require 'twitter-text'
+
+module Panchira
+  class TwitterResolver < Resolver
+    include Twitter::TwitterText::Extractor
+
+    URL_REGEXP = /twitter.com\/\w+\/status\/\d+/.freeze
+
+    private
+      def parse_title
+        @title = super
+      end
+
+      def parse_author
+        @title.match(/\A(.+) on Twitter\z/)[1]
+      end
+
+      def parse_description
+        @description = super.gsub(/\A“|”\z/, '')
+      end
+
+      def parse_tags
+        extract_hashtags(@description)
+      end
+  end
+
+  ::Panchira::Extensions.register(Panchira::TwitterResolver)
+end

--- a/panchira.gemspec
+++ b/panchira.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fastimage', '~> 2.1.7'
   spec.add_dependency 'nokogiri', '>= 1.10.9', '< 1.12.0'
+  spec.add_dependency 'twitter-text', '~>3.1.0'
 end

--- a/test/resolvers/twitter_test.rb
+++ b/test/resolvers/twitter_test.rb
@@ -8,7 +8,15 @@ class TwitterTest < Minitest::Test
     result = Panchira.fetch(url)
 
     assert_match '勃起タイムbot', result.title
-    assert_match '君は中学生なのになかなかの勃起サイズをしているね？', result.description
+    assert_equal '勃起タイムbot', result.author
+    assert_equal '君は中学生なのになかなかの勃起サイズをしているね？', result.description
     assert_match 'https://pbs.twimg.com/media', result.image.url
+
+    # ハッシュタグのテスト
+    url = 'https://twitter.com/atahuta_/status/1360990273619193860'
+    result = Panchira.fetch(url)
+
+    assert_equal 'paizuri_watson #hololewd #amelewd', result.description
+    assert_equal ['hololewd', 'amelewd'], result.tags
   end
 end

--- a/test/resolvers/twitter_test.rb
+++ b/test/resolvers/twitter_test.rb
@@ -4,11 +4,11 @@ require 'test_helper'
 
 class TwitterTest < Minitest::Test
   def test_fetch_twitter
-    url = 'https://twitter.com/mirakuru_rodeo/status/1266016566769926144'
+    url = 'https://twitter.com/bot_erection/status/1412029253906886657'
     result = Panchira.fetch(url)
 
-    assert_match 'みらくるる', result.title
-    assert_match '2巻発売中', result.description
+    assert_match '勃起タイムbot', result.title
+    assert_match '君は中学生なのになかなかの勃起サイズをしているね？', result.description
     assert_match 'https://pbs.twimg.com/media', result.image.url
   end
 end


### PR DESCRIPTION
Twitter用のResolverを作成しました。

年齢確認の回避などの工程が必要ないので、劇的な変化はありませんが、
タイトルからauthorを取得したり、ハッシュタグからtagsを取得したり、descriptionの引用符を外したりします。

また、ハッシュタグを取得する関係で[twitter-text](https://github.com/twitter/twitter-text/tree/master/rb)を実行時依存に加えています。