### PR TITLE
Release 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.6 - 2021-10-19
+### Added
+- Added support for Twitter.
+
+### Changed
+- Melonbooks Resolver now returns image URI without resizing queries.
+
 ## 1.3.5 - 2021-09-01
 ### Added
 - Added support for Pixiv Novel.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.3.5)
+    panchira (1.3.6)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.13.0)
 
@@ -10,15 +10,13 @@ GEM
   specs:
     ast (2.4.2)
     fastimage (2.1.7)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
-    racc (1.6.0)
+    racc (1.5.2)
     rainbow (3.0.0)
     rake (12.3.3)
     regexp_parser (2.1.1)

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.3.5'
+  VERSION = '1.3.6'
 end


### PR DESCRIPTION
## 1.3.6 - 2021-10-19
### Added
- Added support for Twitter.

### Changed
- Melonbooks Resolver now returns image URI without resizing queries.