### PR TITLE
Rubyの最低対応バージョンを2.7に上げる

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: ["2.7", "3.0", "3.1.0-dev"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1.0-dev"]
+        ruby: ["2.7", "3.0"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,22 +9,25 @@ name: Ruby
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
-
     runs-on: ubuntu-18.04
-
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.7, 3.0, 3.1]
+    name: Ruby ${{ matrix.ruby }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.6
-    - name: Install dependencies
-      run: bundle install
-    - name: Run tests
-      run: bundle exec rake test
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-minitest
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   NewCops: enable
   Exclude:
     - bin/*
@@ -27,7 +27,7 @@ Lint/AssignmentInCondition:
   Enabled: false
 
 Lint/MissingSuper:
-  Exclude: 
+  Exclude:
     - lib/panchira/resolvers/*
 
 Style/AsciiComments:

--- a/panchira.gemspec
+++ b/panchira.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
2.6は今年3月にEOLらしいので、とりあえず対応バージョンを2.7以上にしました。
あと、CIを修正して複数バージョンでテストが回るようにしました。