### PR TITLE
Nijie resolverのparse_imageのロジックを変更

### DIFF
--- a/lib/panchira/resolvers/nijie_resolver.rb
+++ b/lib/panchira/resolvers/nijie_resolver.rb
@@ -29,7 +29,6 @@ module Panchira
         str = @page.css('//script[@type="application/ld+json"]/text()').first.to_s.split.join(' ')
         thumbnail_url = JSON.parse(str)['thumbnailUrl']
 
-        # thumbnail_urlが存在しないか、gif画像など動画の場合はロゴ画像を返す
         unless thumbnail_url
           return @page.css('//meta[property="og:image"]/@content').first.to_s
         end

--- a/lib/panchira/resolvers/nijie_resolver.rb
+++ b/lib/panchira/resolvers/nijie_resolver.rb
@@ -1,3 +1,5 @@
+require 'byebug'
+
 # frozen_string_literal: true
 
 module Panchira
@@ -26,17 +28,18 @@ module Panchira
       end
 
       def parse_image_url
-        str = @page.css('//script[@type="application/ld+json"]/text()').first.to_s
+        str = @page.css('//script[@type="application/ld+json"]/text()').first.to_s.split.join(' ')
+        thumbnail_url = JSON.parse(str)['thumbnailUrl']
 
-        if s = str.match(%r{https://pic.nijie.(net|info)/(?<servername>\d+)/[^/]+/nijie_picture/(?<imagename>[^"]+)})
-          # 動画は容量大きすぎるし取らない
-          if s[:imagename] =~ /(jpg|png)/
-            "https://pic.nijie.net/#{s[:servername]}/nijie_picture/#{s[:imagename]}"
-          else
-            s[0]
-          end
+        # thumbnail_urlが存在しないか、gif画像など動画の場合はロゴ画像を返す
+        unless thumbnail_url
+          return @page.css('//meta[property="og:image"]/@content').first.to_s
+        end
+
+        if md = thumbnail_url.match(%r{pic.nijie.net/\w+(?<resolution>/\w+/)nijie.+\.(?<format>png|jpg|jpeg)})
+          thumbnail_url.sub(md[:resolution], '/')
         else
-          @page.css('//meta[property="og:image"]/@content').first.to_s
+          thumbnail_url
         end
       end
 

--- a/lib/panchira/resolvers/nijie_resolver.rb
+++ b/lib/panchira/resolvers/nijie_resolver.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 # frozen_string_literal: true
 
 module Panchira

--- a/test/resolvers/nijie_test.rb
+++ b/test/resolvers/nijie_test.rb
@@ -28,5 +28,13 @@ class NijieTest < Minitest::Test
     assert_equal 'https://pic.nijie.net/05/nijie_picture/3965_20190710041444_0.png', result.image.url
     assert_equal 1764, result.image.width
     assert_equal 1876, result.image.height
+
+    # new image url
+    url = 'https://nijie.info/view.php?id=463339'
+    result = Panchira.fetch(url)
+
+    assert_equal 'https://pic.nijie.net/08/nijie/21/19/1592919/illust/0_0_307cb2b0b570009a_c5e0ff.png', result.image.url
+    assert_equal 737, result.image.width
+    assert_equal 1000, result.image.height
   end
 end


### PR DESCRIPTION
nijie resolverでjsonパースせずに無理やり正規表現で画像のurlを抽出してましたが、url形式に変更が入ったらしく、これを機会にjsonをちゃんとパースするように変更しました。