### PR TITLE
タイムアウトを10秒に設定

### DIFF
--- a/lib/panchira/resolvers/resolver.rb
+++ b/lib/panchira/resolvers/resolver.rb
@@ -53,7 +53,8 @@ module Panchira
       def fetch_page(url)
         read_options = {
           'User-Agent' => user_agent,
-          'Cookie' => cookie
+          'Cookie' => cookie,
+          :read_timeout => 10
         }
 
         raw_page = URI.parse(url).read(read_options)


### PR DESCRIPTION
デフォルトのタイムアウトが60秒と長すぎるので、デフォルトのresolverにだけタイムアウト値を設定しました。一旦10秒で