### PR TITLE
pixiv.cat 介さないURIを返せるようにする

### DIFF
--- a/lib/panchira/resolvers/pixiv_resolver.rb
+++ b/lib/panchira/resolvers/pixiv_resolver.rb
@@ -10,6 +10,8 @@ module Panchira
 
       raw_json = URI.parse("https://www.pixiv.net/ajax/illust/#{@illust_id}").read('User-Agent' => user_agent)
       @json = JSON.parse(raw_json)
+
+      @fetch_raw_image_url = options&.dig(:pixiv, :fetch_raw_image_url)
     end
 
     private
@@ -27,6 +29,10 @@ module Panchira
       end
 
       def parse_image_url
+        if @fetch_raw_image_url
+          return @json['body']['urls']['original']
+        end
+
         proxy_url = "https://pixiv.cat/#{@illust_id}.jpg"
 
         case Net::HTTP.get_response(URI.parse(proxy_url))

--- a/test/resolvers/pixiv_test.rb
+++ b/test/resolvers/pixiv_test.rb
@@ -53,4 +53,11 @@ class PixivTest < Minitest::Test
 
     assert_equal 'https://pixiv.cat/94741740.jpg', result.image.url
   end
+
+  def test_fetch_raw_image
+    url = 'https://www.pixiv.net/artworks/96792681'
+    result = Panchira.fetch(url, {pixiv: {fetch_raw_image_url: true}})
+
+    assert_match 'https://i.pximg.net/img-original/img/', result.image.url
+  end
 end


### PR DESCRIPTION
pixiv.cat のレートリミットに引っかかることが増えてきたため、オリジナルのURIを返せるようにしました。
ただし、返却されたURIを使用するためにはリクエストのRefererの設定が必要なので、デフォルトではpixiv.catを使うままの設定にしてあります。

```ruby
irb(main):001:0> Panchira.fetch "https://www.pixiv.net/artworks/96792681", {pixiv: {fetch_raw_image_url: true}}
=> #<Panchira::PanchiraResult:0x00007f98473037c0 @canonical_url="https://pixiv.net/member_illust.php?mode=medium&illust_id=96792681", @title="盛り盛りYMD", @description="Lカップと聞いて", @image=#<Panchira::PanchiraImage:0x00007f98472b2028 @url="https://i.pximg.net/img-original/img/2022/03/09/19/46/19/96792681_p0.png", @width=nil, @height=nil>, @tags=["R-18", "ラプラス・ダークネス", "hololive", "ホロライブ", "パイズリ希望", "バーチャルYouTuber", "マイクロビキニ", "巨乳", "ロリ爆乳"], @authors=["atahuta"], @circle=nil, @resolver="Panchira::PixivResolver">
```