### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.5.1 - 2022-03-20
+### Added
+- Pixiv resolver can now fetch image URIs that are not proxied.
+
 ## 1.5.0 - 2022-03-01
 ### Changed
 - You can now set options in Panchira::fetch and Resolver's constructors.
-- Twitter resolvers can now fetch datas from API (requires bearer token).
+- Twitter resolver can now fetch datas from API (requires bearer token).
 - Max execution time is now set to 10 seconds.
 
 ## 1.4.0 - 2022-01-10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.5.0)
+    panchira (1.5.1)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.14.0)
 
@@ -10,10 +10,8 @@ GEM
   specs:
     ast (2.4.2)
     fastimage (2.1.7)
-    mini_portile2 (2.8.0)
     minitest (5.15.0)
-    nokogiri (1.13.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.1.1.0)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ To use Twitter API instead of normal scraping, please set Twitter's bearer token
 > Panchira.fetch("https://twitter.com/example/status/1234567890", options: {twitter: {bearer_token: 'ABC...123'}})
 ```
 
+### About Pixiv proxy
+
+By default, Panchira returns a link to [Pixiv.cat](https://pixiv.cat/) as a image URI, but you can change this behavior by setting `fetch_raw_image_url` as an option. To access not-proxied URI, pximg.net, you have to set Referer as `https://app-api.pixiv.net/` in HTTP request header.
+
+```
+> Panchira.fetch("https://pixiv.net/artworks/12345678", options: {pixiv: {fetch_raw_image_url: true}})
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
## 1.5.1 - 2022-03-20
### Added
- Pixiv resolver can now fetch image URIs that are not proxied.