### PR TITLE
Pixiv Resolverの生URI取得時にscaleを取得

### DIFF
--- a/lib/panchira/resolvers/pixiv_resolver.rb
+++ b/lib/panchira/resolvers/pixiv_resolver.rb
@@ -28,6 +28,14 @@ module Panchira
         "https://pixiv.net/member_illust.php?mode=medium&illust_id=#{@illust_id}"
       end
 
+      def parse_image
+        image = PanchiraImage.new
+        image.url = parse_image_url
+        image.width, image.height = FastImage.size(image.url, http_header: {'Referer' => 'https://app-api.pixiv.net/'})
+
+        image
+      end
+
       def parse_image_url
         if @fetch_raw_image_url
           return @json['body']['urls']['original']

--- a/test/resolvers/pixiv_test.rb
+++ b/test/resolvers/pixiv_test.rb
@@ -59,5 +59,7 @@ class PixivTest < Minitest::Test
     result = Panchira.fetch(url, {pixiv: {fetch_raw_image_url: true}})
 
     assert_match 'https://i.pximg.net/img-original/img/', result.image.url
+    assert_equal 1631, result.image.width
+    assert_equal 2300, result.image.height
   end
 end


### PR DESCRIPTION
FastImageで画像が取得できてなかった