### PR TITLE
release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.5.2 - 2022-03-20
 ### Fixed
-- Fixed an issue where Pixiv resolver can't retreive not-proxied image scales.
+- Fixed an issue where Pixiv resolver can't retrieve not-proxied image scales.
 
 ## 1.5.1 - 2022-03-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.5.2 - 2022-03-20
+### Fixed
+- Fixed an issue where Pixiv resolver can't retreive not-proxied image scales.
+
 ## 1.5.1 - 2022-03-20
 ### Added
 - Pixiv resolver can now fetch image URIs that are not proxied.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.5.1)
+    panchira (1.5.2)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.14.0)
 

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 end


### PR DESCRIPTION
## 1.5.2 - 2022-03-20
### Fixed
- Fixed an issue where Pixiv resolver can't retrieve not-proxied image scales.