### PR TITLE
Release 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.5.3 - 2022-06-04
+### Fixed
+- Fixed an issue where Pixiv resolver can't retrieve image urls for manga.
+
+### Changed
+- DLsite resolver now returns descriptions without platform PR sentences.
+
 ## 1.5.2 - 2022-03-20
 ### Fixed
 - Fixed an issue where Pixiv resolver can't retrieve not-proxied image scales.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.5.2)
+    panchira (1.5.3)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.14.0)
 
@@ -10,10 +10,8 @@ GEM
   specs:
     ast (2.4.2)
     fastimage (2.1.7)
-    mini_portile2 (2.8.0)
     minitest (5.15.0)
-    nokogiri (1.13.6)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,10 @@ GEM
   specs:
     ast (2.4.2)
     fastimage (2.1.7)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
-    nokogiri (1.13.3-x86_64-darwin)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.1.1.0)
@@ -39,6 +41,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.0)

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 end


### PR DESCRIPTION
## 1.5.3 - 2022-06-04
### Fixed
- Fixed an issue where Pixiv resolver can't retrieve image urls for manga.

### Changed
- DLsite resolver now returns descriptions without platform PR sentences.