### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.6.0 - 2023-01-05
+### Added
+- Added support for non-Japanese DLsite URLs.
+
+### Fixed
+- Fixed an issue where FANZA resolver don't work due to renewal of the website.
+- Fixed an issue where Melonbooks resolver don't work due to renewal of the website.
+
 ## 1.5.3 - 2022-06-04
 ### Fixed
 - Fixed an issue where Pixiv resolver can't retrieve image urls for manga.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,17 +142,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 0.1.0 - 2020-05-13 [YANKED]
 ### Added
 - Released Panchira gem. At this time we can parse only 5 websites.
-
-[1.3.5]: https://github.com/nuita/panchira/releases/tag/v1.3.5
-[1.3.4]: https://github.com/nuita/panchira/releases/tag/v1.3.4
-[1.3.3]: https://github.com/nuita/panchira/releases/tag/v1.3.3
-[1.3.2]: https://github.com/nuita/panchira/releases/tag/v1.3.2
-[1.3.1]: https://github.com/nuita/panchira/releases/tag/v1.3.1
-[1.3.0]: https://github.com/nuita/panchira/releases/tag/v1.3.0
-[1.2.0]: https://github.com/nuita/panchira/releases/tag/v1.2.0
-[1.1.0]: https://github.com/nuita/panchira/releases/tag/v1.1.0
-[1.0.0]: https://github.com/nuita/panchira/releases/tag/v1.0.0
-[0.3.0]: https://github.com/nuita/panchira/releases/tag/v0.3.0
-[0.2.0]: https://github.com/nuita/panchira/releases/tag/v0.2.0
-[0.1.1]: https://github.com/nuita/panchira/releases/tag/v0.1.1
-[0.1.0]: https://github.com/nuita/panchira/releases/tag/v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.5.3)
+    panchira (1.6.0)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.14.0)
 
@@ -10,34 +10,36 @@ GEM
   specs:
     ast (2.4.2)
     fastimage (2.1.7)
-    mini_portile2 (2.8.0)
-    minitest (5.15.0)
-    nokogiri (1.13.6)
+    json (2.6.3)
+    mini_portile2 (2.8.1)
+    minitest (5.17.0)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
-    parser (3.1.2.0)
+    parser (3.2.0.0)
       ast (~> 2.4.1)
-    racc (1.6.0)
+    racc (1.6.2)
     rainbow (3.1.1)
     rake (12.3.3)
-    regexp_parser (2.5.0)
+    regexp_parser (2.6.1)
     rexml (3.2.5)
-    rubocop (1.30.0)
+    rubocop (1.42.0)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.18.0, < 2.0)
+      rubocop-ast (>= 1.24.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.18.0)
+    rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
-    rubocop-minitest (0.20.0)
+    rubocop-minitest (0.25.1)
       rubocop (>= 0.90, < 2.0)
     ruby-progressbar (1.11.0)
-    unicode-display_width (2.1.0)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby
@@ -52,4 +54,4 @@ DEPENDENCIES
   rubocop-minitest (~> 0.10)
 
 BUNDLED WITH
-   2.1.4
+   2.4.2

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.5.3'
+  VERSION = '1.6.0'
 end


### PR DESCRIPTION
## 1.6.0 - 2023-01-05
### Added
- Added support for non-Japanese DLsite URLs.

### Fixed
- Fixed an issue where FANZA resolver don't work due to renewal of the website.
- Fixed an issue where Melonbooks resolver don't work due to renewal of the website.