### PR TITLE
release 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.6.1 - 2023-01-17
+### Added
+- Pixiv resolver now retrieves AI-generated information as a tag.
+
 ## 1.6.0 - 2023-01-05
 ### Added
 - Added support for non-Japanese DLsite URLs.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    panchira (1.6.0)
+    panchira (1.6.1)
       fastimage (~> 2.1.7)
       nokogiri (>= 1.10.9, < 1.14.0)
 

--- a/lib/panchira/version.rb
+++ b/lib/panchira/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panchira
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end


### PR DESCRIPTION
## 1.6.1 - 2023-01-17
### Added
- Pixiv resolver now retrieves AI-generated information as a tag.